### PR TITLE
Translate Dream Beach dialogue into Russian

### DIFF
--- a/client/src/features/dialogue/DialogueView.tsx
+++ b/client/src/features/dialogue/DialogueView.tsx
@@ -26,7 +26,7 @@ export function DialogueView() {
   if (!session) {
     return (
       <div className="rounded-lg border border-slate-700/60 bg-slate-900/80 p-6 text-slate-200">
-        <p>No voices are calling right now.</p>
+        <p>Сейчас никаких голосов не слышно.</p>
       </div>
     );
   }
@@ -35,7 +35,7 @@ export function DialogueView() {
   if (!node) {
     return (
       <div className="rounded-lg border border-rose-700/40 bg-rose-900/40 p-6 text-rose-100">
-        <p>The dream failed to recall this memory.</p>
+        <p>Сну не удалось вернуть это воспоминание.</p>
       </div>
     );
   }
@@ -46,7 +46,7 @@ export function DialogueView() {
 
   return (
     <div className="mx-auto max-w-3xl rounded-lg border border-indigo-500/60 bg-slate-900/90 p-8 shadow-lg shadow-indigo-900/30">
-      <h2 className="text-xl font-semibold text-indigo-200">Dream Beach</h2>
+      <h2 className="text-xl font-semibold text-indigo-200">Пляж Снов</h2>
       <p className="mt-4 text-lg leading-relaxed text-slate-100">{applyHero(node.text, hero)}</p>
 
       <div className="mt-6 flex flex-col gap-3">
@@ -64,7 +64,7 @@ export function DialogueView() {
             className="rounded-md border border-slate-500/50 bg-slate-500/10 px-4 py-2 text-left text-slate-200"
             onClick={() => advanceDialogue("start")}
           >
-            Listen to the surf again
+            Снова прислушаться к прибою
           </button>
         )}
       </div>

--- a/shared/content/dialogueBeach.json
+++ b/shared/content/dialogueBeach.json
@@ -1,19 +1,19 @@
 ﻿[
   {
     "id": "start",
-    "text": "Lister watches the tide of starlight. \"Three shards drift inside the Palace of Fear. Bring them back, {{hero}}, and the dream remembers hope.\"",
+    "text": "Листер наблюдает за приливом звездного света. \"Три осколка дрейфуют внутри Дворца Страха. Верни их, {{hero}}, и сон вспомнит надежду.\"",
     "choices": [
       {
-        "label": "I'm ready to step inside the palace.",
+        "label": "Я готов войти во дворец.",
         "next": "enter_palace",
         "setFlags": { "metLister": true }
       },
       {
-        "label": "Tell me more about the shards.",
+        "label": "Расскажи мне больше об осколках.",
         "next": "shard_brief"
       },
       {
-        "label": "The shards are resonating...",
+        "label": "Осколки резонируют...",
         "next": "shard_reflection",
         "requiresFlags": { "shard1": true }
       }
@@ -21,24 +21,24 @@
   },
   {
     "id": "shard_brief",
-    "text": "\"Each shard is a forgotten courage. Hold them close, and the Avatar's mask cracks. Even the companions hear the song.\"",
+    "text": "\"Каждый осколок — забытое мужество. Храни их рядом, и маска Аватара треснет. Даже спутники услышат песнь.\"",
     "choices": [
       {
-        "label": "I'll remember that.",
+        "label": "Я запомню это.",
         "next": "start"
       },
       {
-        "label": "Can they help the companions?",
+        "label": "Они помогут спутникам?",
         "next": "companion_hint"
       }
     ]
   },
   {
     "id": "companion_hint",
-    "text": "\"If you trust them, {{hero}}, they answer in harmony. A synchronized skill waits for the brave.\"",
+    "text": "\"Если доверишься им, {{hero}}, они ответят в унисон. Синхронное умение ждёт отважных.\"",
     "choices": [
       {
-        "label": "Promise to fight together.",
+        "label": "Обещаю сражаться вместе.",
         "next": "start",
         "setFlags": { "unlockCompanionSkill": true }
       }
@@ -46,53 +46,53 @@
   },
   {
     "id": "shard_reflection",
-    "text": "Lister traces sigils in the tide. \"I can hear at least one shard in your voice, {{hero}}. When all three glow, the Avatar will falter.\"",
+    "text": "Листер чертит знаки в приливе. \"Я слышу хотя бы один осколок в твоём голосе, {{hero}}. Когда все три засияют, Аватар дрогнет.\"",
     "choices": [
       {
-        "label": "I found one shard.",
+        "label": "У меня есть один осколок.",
         "next": "shard_one_echo",
         "requiresFlags": { "shard1": true, "shard2": false }
       },
       {
-        "label": "Two shards hum in resonance.",
+        "label": "Два осколка звучат в унисон.",
         "next": "shard_two_echo",
         "requiresFlags": { "shard1": true, "shard2": true, "shard3": false }
       },
       {
-        "label": "All three shards answer each other.",
+        "label": "Все три осколка откликаются друг другу.",
         "next": "shard_three_echo",
         "requiresFlags": { "shard1": true, "shard2": true, "shard3": true }
       },
       {
-        "label": "That's enough for now.",
+        "label": "На сейчас этого достаточно.",
         "next": "start"
       }
     ]
   },
   {
     "id": "shard_one_echo",
-    "text": "\"The first shard softens the Avatar's glare. It will lose one of its masks when you face it.\"",
+    "text": "\"Первый осколок смягчит взгляд Аватара. Когда встретишься с ним, он потеряет одну из своих масок.\"",
     "choices": [
-      { "label": "Return to the surf.", "next": "start" }
+      { "label": "Вернуться к прибою.", "next": "start" }
     ]
   },
   {
     "id": "shard_two_echo",
-    "text": "\"With two shards, Fear hesitates. It can no longer shield itself behind ice.\"",
+    "text": "\"С двумя осколками Страх колеблется. Он больше не сможет укрыться за льдом.\"",
     "choices": [
-      { "label": "Return to the surf.", "next": "start" }
+      { "label": "Вернуться к прибою.", "next": "start" }
     ]
   },
   {
     "id": "shard_three_echo",
-    "text": "\"All three? Then the Avatar's opening blow will falter. I'll weave a protective echo when you face it, {{hero}}.\"",
+    "text": "\"Все три? Тогда первый удар Аватара дрогнет. Когда ты столкнёшься с ним, {{hero}}, я сотку защитное эхо.\"",
     "choices": [
-      { "label": "Let the echo follow me.", "next": "start", "setFlags": { "bossOpeningDebuff": true } }
+      { "label": "Пусть эхо сопровождает меня.", "next": "start", "setFlags": { "bossOpeningDebuff": true } }
     ]
   },
   {
     "id": "enter_palace",
-    "text": "\"Follow the ribbon of moonlight, {{hero}}. When you return, bring a story.\"",
+    "text": "\"Следуй по ленте лунного света, {{hero}}. Когда вернёшься, принеси историю.\"",
     "end": true
   }
 ]


### PR DESCRIPTION
## Summary
- localize the dialogue interface texts on the dream beach screen into Russian
- translate the Dream Beach branching dialogue script to Russian

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de62b016e48329bf716a69024f73ae