### PR TITLE
Restrict game log to key progression events

### DIFF
--- a/client/src/features/combat/hooks/useCombat.ts
+++ b/client/src/features/combat/hooks/useCombat.ts
@@ -88,7 +88,10 @@ export function useCombat(): UseCombatResult {
   useEffect(() => {
     if (!combat || !encounter || !combat.ended || resolvedRef.current) return;
     resolvedRef.current = true;
-    const lastMessages = combat.eventsLog.slice(-6).map((event) => event.message ?? event.type);
+    const lastMessages = combat.eventsLog
+      .slice(-6)
+      .map((event) => event.message)
+      .filter((message): message is string => Boolean(message) && !message.startsWith("combat.events."));
     resolveEncounter({
       encounterId: encounter.id,
       victory: combat.winner === "allies",


### PR DESCRIPTION
## Summary
- filter combat event messages before sending combat resolution back to the game state
- add helpers to only persist allowed log messages and record a room-cleared entry for guard victories
- remove miscellaneous narrative and XP entries from the log so it now only tracks level ups, skill unlocks, shard collection, and cleared rooms

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de6b5ad4c883298ef1b49dadb45725