### PR TITLE
Restrict game log to key progression events

### DIFF
--- a/client/src/features/combat/hooks/useCombat.ts
+++ b/client/src/features/combat/hooks/useCombat.ts
@@ -88,7 +88,13 @@ export function useCombat(): UseCombatResult {
   useEffect(() => {
     if (!combat || !encounter || !combat.ended || resolvedRef.current) return;
     resolvedRef.current = true;
-    const lastMessages = combat.eventsLog.slice(-6).map((event) => event.message ?? event.type);
+    const lastMessages = combat.eventsLog
+      .slice(-6)
+      .map((event) => event.message)
+      .filter((message): message is string => {
+        if (!message) return false;
+        return !message.startsWith("combat.events.");
+      });
     resolveEncounter({
       encounterId: encounter.id,
       victory: combat.winner === "allies",

--- a/client/src/state/GameContext.tsx
+++ b/client/src/state/GameContext.tsx
@@ -98,6 +98,13 @@ function appendAllowedLog(log: string[], message: string): string[] {
   return [...log, message].slice(-20);
 }
 
+function appendAllowedLogs(log: string[], messages: readonly string[]): string[] {
+  if (!messages.length) {
+    return log;
+  }
+  return messages.reduce((current, message) => appendAllowedLog(current, message), log);
+}
+
 function createInitialState(): AppState {
   const progression: ProgressionState = { level: 1, xp: 0 };
   const flags: Record<string, boolean> = {};
@@ -422,11 +429,11 @@ function reducer(state: AppState, action: any): AppState {
     case "START_ENCOUNTER":
       return { ...state, mode: "combat", activeEncounterId: action.payload };
     case "RESOLVE_COMBAT": {
-      const { encounterId, victory, rewards } = action.payload as CombatResolution;
+      const { encounterId, victory, rewards, messages } = action.payload as CombatResolution;
       let flags = state.flags;
       let inventory = state.inventory;
       let mode: GameMode = "exploration";
-      let log = state.log;
+      let log = appendAllowedLogs(state.log, messages ?? []);
       let progression = state.progression ?? { level: 1, xp: 0 };
       let companionLevel = state.companionLevel ?? progression.level;
       let unlockedSkills = state.unlockedSkills ?? {};


### PR DESCRIPTION
## Summary
- filter combat event messages before sending combat resolution back to the game state
- add helpers to only persist allowed log messages and record a room-cleared entry for guard victories
- remove miscellaneous narrative and XP entries from the log so it now only tracks level ups, skill unlocks, shard collection, and cleared rooms
- guard the combat log filtering against undefined messages before checking their prefixes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de6b5ad4c883298ef1b49dadb45725