### PR TITLE
Implement random encounters and optional palace rooms

### DIFF
--- a/client/src/features/exploration/ExplorationView.tsx
+++ b/client/src/features/exploration/ExplorationView.tsx
@@ -19,6 +19,10 @@ const roomMetadata: Record<string, RoomMetadata> = {
     name: "Зал эха",
     description: "Колонны напевают забытые страхи. Здесь роятся слабые тени, испытывая вашу решимость.",
   },
+  guard_room: {
+    name: "Комната стражи",
+    description: "Небольшой караул хоронит усталость среди копий и полированных шлемов.",
+  },
   library: {
     name: "Лабиринт томов",
     description: "Полки, наполненные тревожными хрониками, охраняют первый осколок. Страж ревниво следит за каждым шагом.",
@@ -27,9 +31,17 @@ const roomMetadata: Record<string, RoomMetadata> = {
     name: "Галерея отражений",
     description: "Картины оживают и шепчут чужие кошмары. Второй осколок прячется среди разбитых рам.",
   },
+  servants_room: {
+    name: "Комната прислуги",
+    description: "Аромат лавандового масла и аккуратно сложенное бельё скрывают незаметные тайники.",
+  },
   vault: {
     name: "Сокровищница шрама",
     description: "Три запечатанных сердца бьются в унисон, охраняемые последним стражем. Здесь скрыт финальный осколок.",
+  },
+  royal_bedroom: {
+    name: "Королевская спальня",
+    description: "Золочёные занавеси дрожат от невидимого сквозняка. Тайны правителя заперты вместе с бдительными стражами.",
   },
   gate: {
     name: "Врата Аватара",
@@ -40,9 +52,12 @@ const roomMetadata: Record<string, RoomMetadata> = {
 const roomPositions: Record<string, { x: number; y: number }> = {
   entry: { x: 12, y: 52 },
   hall: { x: 36, y: 52 },
+  guard_room: { x: 48, y: 36 },
   library: { x: 58, y: 28 },
   gallery: { x: 58, y: 76 },
+  servants_room: { x: 70, y: 68 },
   vault: { x: 82, y: 52 },
+  royal_bedroom: { x: 82, y: 32 },
   gate: { x: 92, y: 18 },
 };
 
@@ -59,11 +74,15 @@ function formatRoomId(id: string) {
 }
 
 export function ExplorationView() {
-  const { state, moveToRoom, collectShard, startEncounter, openDialogue } = useGame();
+  const { state, moveToRoom, collectShard, startEncounter, openDialogue, claimRoomLoot } =
+    useGame();
   const baseRoom = roomIndex.get(state.location.roomId);
   const roomState = baseRoom ? state.roomStates[baseRoom.id] : undefined;
   const room = baseRoom
-    ? ({ ...baseRoom, ...roomState } as typeof baseRoom & { shardCollected?: boolean })
+    ? ({ ...baseRoom, ...roomState } as typeof baseRoom & {
+        shardCollected?: boolean;
+        lootClaimed?: boolean;
+      })
     : undefined;
 
   const edges = useMemo(() => {
@@ -90,6 +109,8 @@ export function ExplorationView() {
     ? state.flags[`encounter_${guardEncounter.id}_cleared`]
     : false;
   const shardAvailable = room.shardId && !state.flags[room.shardId] && guardCleared;
+  const lootAvailable = Boolean(room.loot && !room.lootClaimed);
+  const lootAlreadyClaimed = Boolean(room.loot && room.lootClaimed);
 
   const bossEncounter = getEncounter(palaceLayout.bossEncounterId);
   const bossCleared = bossEncounter
@@ -204,6 +225,21 @@ export function ExplorationView() {
             {guardEncounter && guardCleared && (
               <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-100">
                 Страж отступил. Комната спит спокойно.
+              </div>
+            )}
+
+            {lootAvailable && room.loot && (
+              <button
+                className="block w-full rounded-md border border-sky-400/70 bg-sky-400/20 px-4 py-3 text-left text-sm text-sky-100 transition hover:bg-sky-400/30"
+                onClick={() => claimRoomLoot(room.id)}
+              >
+                {room.loot.actionLabel ?? "Обыскать комнату"}
+              </button>
+            )}
+
+            {lootAlreadyClaimed && (
+              <div className="rounded-md border border-sky-300/40 bg-sky-300/10 px-4 py-3 text-sm text-sky-100">
+                Комната уже обыскана.
               </div>
             )}
 

--- a/client/src/state/content.ts
+++ b/client/src/state/content.ts
@@ -4,7 +4,15 @@ import progressionData from "@shared/content/progression.json" assert { type: "j
 import skillUnlocksData from "@shared/content/skillUnlocks.json" assert { type: "json" };
 import palaceLayoutData from "@shared/content/palaceFear.json" assert { type: "json" };
 import dialogueBeachData from "@shared/content/dialogueBeach.json" assert { type: "json" };
-import type { Skill, Actor, PalaceLayout, DialogueNode, SkillUnlockDefinition } from "@shared/types";
+import type {
+  Skill,
+  Actor,
+  PalaceLayout,
+  DialogueNode,
+  SkillUnlockDefinition,
+  PalaceEncounterTablesConfig,
+} from "@shared/types";
+import encounterTablesData from "@shared/content/encounters.json" assert { type: "json" };
 
 export const skills = Object.fromEntries(
   (skillsData as Skill[]).map((skill) => [skill.id, skill])
@@ -20,3 +28,4 @@ export const skillUnlocks = skillUnlocksData as Record<string, SkillUnlockDefini
 
 export const palaceLayout = palaceLayoutData as PalaceLayout;
 export const dialogueBeach = dialogueBeachData as DialogueNode[];
+export const encounterTablesConfig = encounterTablesData as PalaceEncounterTablesConfig;

--- a/client/src/state/encounters.ts
+++ b/client/src/state/encounters.ts
@@ -32,12 +32,61 @@ function cloneActorWithStats(actor: Actor, overrides?: Partial<Actor["stats"]>):
 }
 
 export const encounters: Record<string, EncounterDefinition> = {
+  e_w1: {
+    id: "e_w1",
+    name: "Шёпот тени",
+    description: "Одинокий сторож ночи пытается отрезать путь.",
+    enemies: [cloneActor(enemies.shadow_crawler)],
+  },
+  e_w2: {
+    id: "e_w2",
+    name: "Тени в паре",
+    description: "Два стража страха синхронно обступают вас.",
+    enemies: [cloneActor(enemies.shadow_crawler), cloneActor(enemies.shadow_crawler)],
+  },
+  e_m1: {
+    id: "e_m1",
+    name: "Рёв призрачной трубы",
+    description: "Тень-скример взламывает тишину высокими аккордами.",
+    enemies: [cloneActor(enemies.shadow_screamer)],
+  },
+  e_m2: {
+    id: "e_m2",
+    name: "Дежурство дозорных",
+    description: "Слаженная пара тени и крика пытается загнать вас в угол.",
+    enemies: [cloneActor(enemies.shadow_crawler), cloneActor(enemies.shadow_screamer)],
+  },
+  e_h1: {
+    id: "e_h1",
+    name: "Хор расколотых зеркал",
+    description: "Две Screamer-тени вплетают голоса в смертельный дуэт.",
+    enemies: [cloneActor(enemies.shadow_screamer), cloneActor(enemies.shadow_screamer)],
+  },
+  e_h2: {
+    id: "e_h2",
+    name: "Осадный символ",
+    description: "Укреплённая Screamer несёт резонансные печати страха.",
+    enemies: [
+      cloneActorWithStats(enemies.shadow_screamer, {
+        maxHP: 86,
+        mag: 13,
+        res: 9,
+      }),
+    ],
+  },
   guard1: {
     id: "guard1",
     name: "Страж Библиотеки",
     description: "Бестелесный рыцарь охраняет первый осколок среди безмолвных полок.",
     enemies: [cloneActor(enemies.shadow_crawler)],
     reward: { items: [{ id: "dream_tonic", qty: 1 }] },
+  },
+  guard_watch: {
+    id: "guard_watch",
+    name: "Дежурный страж",
+    description: "Единичная тень подмечает каждое движение в караульной комнате.",
+    enemies: [cloneActorWithStats(enemies.shadow_crawler, { maxHP: 50, def: 7 })],
+    reward: { items: [{ id: "dream_tonic", qty: 2 }] },
   },
   guard2: {
     id: "guard2",
@@ -60,6 +109,16 @@ export const encounters: Record<string, EncounterDefinition> = {
       }),
     ],
     reward: { items: [{ id: "dream_tonic", qty: 2 }] },
+  },
+  guard_royal: {
+    id: "guard_royal",
+    name: "Стражи Опочивальни",
+    description: "Пара закованных теней охраняет тайны королевской спальни.",
+    enemies: [
+      cloneActorWithStats(enemies.shadow_screamer, { maxHP: 72, str: 9, mag: 12 }),
+      cloneActorWithStats(enemies.shadow_screamer, { maxHP: 72, str: 9, mag: 12 }),
+    ],
+    reward: { items: [{ id: "royal_diary_page", qty: 1 }] },
   },
   boss_fear: {
     id: "boss_fear",

--- a/client/src/state/items.ts
+++ b/client/src/state/items.ts
@@ -13,4 +13,15 @@ export const itemCatalog: Record<string, ItemDefinition> = {
     description: "Mends 40 HP with cooling starlight.",
     healHP: 40,
   },
+  starlight_infusion: {
+    id: "starlight_infusion",
+    name: "Starlight Infusion",
+    description: "Restores 25 SP with gentle moonfire.",
+    healSP: 25,
+  },
+  royal_diary_page: {
+    id: "royal_diary_page",
+    name: "Royal Diary Page",
+    description: "A perfumed letter chronicling the palace sovereign's final night.",
+  },
 };

--- a/shared/content/encounters.json
+++ b/shared/content/encounters.json
@@ -1,0 +1,20 @@
+{
+  "tables": {
+    "weak": [
+      { "id": "e_w1", "weight": 50 },
+      { "id": "e_w2", "weight": 50 }
+    ],
+    "mid": [
+      { "id": "e_m1", "weight": 60 },
+      { "id": "e_m2", "weight": 40 }
+    ],
+    "hard": [
+      { "id": "e_h1", "weight": 70 },
+      { "id": "e_h2", "weight": 30 }
+    ]
+  },
+  "cooldownSteps": 1,
+  "baseChance": 0.35,
+  "chanceStep": 0.15,
+  "maxChance": 0.85
+}

--- a/shared/content/palaceFear.json
+++ b/shared/content/palaceFear.json
@@ -6,17 +6,27 @@
       "neighbors": [
         "hall",
         "gallery"
-      ],
-      "encounterTable": "weak"
+      ]
     },
     {
       "id": "hall",
       "type": "combat",
       "neighbors": [
         "entry",
-        "library"
+        "library",
+        "guard_room"
       ],
       "encounterTable": "weak"
+    },
+    {
+      "id": "guard_room",
+      "type": "combat",
+      "neighbors": [
+        "hall",
+        "servants_room"
+      ],
+      "encounterTable": "mid",
+      "guardEncounter": "guard_watch"
     },
     {
       "id": "library",
@@ -30,15 +40,43 @@
       "guardEncounter": "guard1"
     },
     {
+      "id": "servants_room",
+      "type": "lore",
+      "neighbors": [
+        "guard_room",
+        "gallery"
+      ],
+      "encounterTable": "weak",
+      "loot": {
+        "items": [
+          { "id": "starlight_infusion", "qty": 1 }
+        ],
+        "actionLabel": "Обыскать комнату",
+        "logMessage": "Найдено: запечатанный флакон звездной эссенции."
+      }
+    },
+    {
       "id": "gallery",
       "type": "shard",
       "shardId": "shard2",
       "neighbors": [
         "entry",
-        "vault"
+        "vault",
+        "servants_room",
+        "royal_bedroom"
       ],
       "encounterTable": "mid",
       "guardEncounter": "guard2"
+    },
+    {
+      "id": "royal_bedroom",
+      "type": "combat",
+      "neighbors": [
+        "gallery",
+        "vault"
+      ],
+      "encounterTable": "hard",
+      "guardEncounter": "guard_royal"
     },
     {
       "id": "vault",
@@ -47,6 +85,7 @@
       "neighbors": [
         "library",
         "gallery",
+        "royal_bedroom",
         "gate"
       ],
       "encounterTable": "hard",

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -68,19 +68,39 @@ export interface DialogueNode {
 
 export type PalaceEncounterTable = 'weak' | 'mid' | 'hard';
 
+export interface PalaceRoomLoot {
+  items?: Array<{ id: string; qty: number }>;
+  logMessage?: string;
+  actionLabel?: string;
+}
+
 export interface PalaceRoom {
   id: string;
-  type: 'entry' | 'combat' | 'shard' | 'boss';
+  type: 'entry' | 'combat' | 'shard' | 'boss' | 'lore';
   neighbors: string[];
   shardId?: string;
   encounterTable?: PalaceEncounterTable;
   guardEncounter?: string;
   shardCollected?: boolean;
+  loot?: PalaceRoomLoot;
 }
 
 export interface PalaceLayout {
   rooms: PalaceRoom[];
   bossEncounterId: string;
+}
+
+export interface PalaceEncounterTableEntry {
+  id: string;
+  weight: number;
+}
+
+export interface PalaceEncounterTablesConfig {
+  tables: Record<PalaceEncounterTable, PalaceEncounterTableEntry[]>;
+  cooldownSteps: number;
+  baseChance: number;
+  chanceStep: number;
+  maxChance: number;
 }
 
 export interface GameState {


### PR DESCRIPTION
## Summary
- add encounter table configuration and weighted random encounter selection with cooldown-based chance adjustments
- introduce guard, servant, and royal bedroom chambers with new encounters, loot, and inventory items
- update exploration UI to surface loot interactions and reflect the expanded palace layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de7537d0fc83298eeb5ea8cf340657