### PR TITLE
Implement reactive save/load controls

### DIFF
--- a/client/src/features/save/saveSystem.ts
+++ b/client/src/features/save/saveSystem.ts
@@ -2,25 +2,59 @@ import type { AppState } from "@/state/GameContext";
 
 const STORAGE_KEY = "dream_shards_save_v1";
 const VERSION = "1.0.0";
+const SNAPSHOT_EVENT = "dreamshards:snapshot-updated";
 
-interface SaveFile {
+export interface SaveFile {
   version: string;
   timestamp: number;
   state: AppState;
 }
 
+declare global {
+  interface WindowEventMap {
+    "dreamshards:snapshot-updated": CustomEvent<SaveFile | null>;
+  }
+}
+
+function getStorage(): Storage | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    return window.localStorage;
+  } catch (error) {
+    console.warn("Local storage unavailable", error);
+    return null;
+  }
+}
+
+function dispatchSnapshotEvent(snapshot: SaveFile | null) {
+  if (typeof window === "undefined") {
+    return;
+  }
+  const event = new CustomEvent(SNAPSHOT_EVENT, { detail: snapshot });
+  window.dispatchEvent(event);
+}
+
 export function saveSnapshot(state: AppState) {
+  const storage = getStorage();
+  if (!storage) {
+    return null;
+  }
   const payload: SaveFile = {
     version: VERSION,
     timestamp: Date.now(),
     state,
   };
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  storage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  dispatchSnapshotEvent(payload);
   return payload;
 }
 
 export function loadSnapshot(): SaveFile | null {
-  const raw = localStorage.getItem(STORAGE_KEY);
+  const storage = getStorage();
+  if (!storage) return null;
+  const raw = storage.getItem(STORAGE_KEY);
   if (!raw) return null;
   try {
     const parsed = JSON.parse(raw) as SaveFile;
@@ -32,7 +66,28 @@ export function loadSnapshot(): SaveFile | null {
 }
 
 export function clearSnapshot() {
-  localStorage.removeItem(STORAGE_KEY);
+  const storage = getStorage();
+  if (!storage) {
+    return;
+  }
+  storage.removeItem(STORAGE_KEY);
+  dispatchSnapshotEvent(null);
+}
+
+export function subscribeToSnapshotChange(
+  listener: (snapshot: SaveFile | null) => void,
+): () => void {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+  const handler = (event: Event) => {
+    const custom = event as CustomEvent<SaveFile | null>;
+    listener(custom.detail ?? null);
+  };
+  window.addEventListener(SNAPSHOT_EVENT, handler);
+  return () => {
+    window.removeEventListener(SNAPSHOT_EVENT, handler);
+  };
 }
 
 export async function pushSnapshotToServer(state: AppState) {


### PR DESCRIPTION
## Summary
- add snapshot change events and a subscription helper for the save system
- wire the main menu and top bar to reflect save availability and hydrate from cached state
- disable save/load buttons when no snapshot is present to match intended flow

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68de91d5ad188329ba85f8e651082b9a