### PR TITLE
Create saves table automatically before remote save

### DIFF
--- a/server/src/db/drizzle.ts
+++ b/server/src/db/drizzle.ts
@@ -12,6 +12,19 @@ const defaultPath = process.env.DATABASE_FILE
 fs.mkdirSync(path.dirname(defaultPath), { recursive: true });
 
 const sqlite = new Database(defaultPath);
+
+function ensureSchema(database: typeof sqlite) {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS "saves" (
+      "id" integer PRIMARY KEY AUTOINCREMENT,
+      "created_at" integer NOT NULL DEFAULT (strftime('%s','now')),
+      "payload" text NOT NULL
+    )
+  `);
+}
+
+ensureSchema(sqlite);
+
 export const db = drizzle(sqlite);
 
 export async function insertSave(payload: InsertSave["payload"]): Promise<number> {


### PR DESCRIPTION
## Summary
- ensure the SQLite schema is created so the saves table exists before handling requests

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dec533dd208329a28f31f27e782072