### PR TITLE
Fix Windows standalone build entrypoint

### DIFF
--- a/server/src/vite.ts
+++ b/server/src/vite.ts
@@ -7,8 +7,12 @@ import { type Server } from "http";
 import { nanoid } from "nanoid";
 import viteConfig from "../../vite.config";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const moduleFilename =
+  typeof __filename === "string"
+    ? __filename
+    : fileURLToPath(import.meta.url);
+const moduleDirname =
+  typeof __dirname === "string" ? __dirname : path.dirname(moduleFilename);
 const viteLogger = createLogger();
 
 export function log(message: string, source = "express") {
@@ -48,7 +52,13 @@ export async function setupVite(app: Express, server: Server) {
     const url = req.originalUrl;
 
     try {
-      const clientTemplate = path.resolve(__dirname, "..", "..", "client", "index.html");
+      const clientTemplate = path.resolve(
+        moduleDirname,
+        "..",
+        "..",
+        "client",
+        "index.html",
+      );
       let template = await fs.promises.readFile(clientTemplate, "utf-8");
       template = template.replace(
         `src="/src/main.tsx"`,
@@ -68,7 +78,7 @@ function resolveDistRoot() {
     return path.dirname(process.execPath);
   }
 
-  return path.resolve(__dirname, "..");
+  return path.resolve(moduleDirname, "..");
 }
 
 export function serveStatic(app: Express) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,8 +5,12 @@ import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 import { fileURLToPath } from "url";
 import glsl from "vite-plugin-glsl";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+const moduleFilename =
+  typeof __filename === "string"
+    ? __filename
+    : fileURLToPath(import.meta.url);
+const moduleDirname =
+  typeof __dirname === "string" ? __dirname : dirname(moduleFilename);
 
 export default defineConfig({
   plugins: [
@@ -16,13 +20,13 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "client", "src"),
-      "@shared": path.resolve(__dirname, "shared"),
+      "@": path.resolve(moduleDirname, "client", "src"),
+      "@shared": path.resolve(moduleDirname, "shared"),
     },
   },
-  root: path.resolve(__dirname, "client"),
+  root: path.resolve(moduleDirname, "client"),
   build: {
-    outDir: path.resolve(__dirname, "dist/public"),
+    outDir: path.resolve(moduleDirname, "dist/public"),
     emptyOutDir: true,
   },
   // Add support for large models and audio files


### PR DESCRIPTION
## Summary
- add a CommonJS server bundle for pkg when building the Windows standalone executable
- make server and Vite config runtime-dir resolution work in both ESM and CommonJS environments

## Testing
- npm run build:standalone:win
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68deca87cec0832994e5258cd73f7990