### PR TITLE
Prevent pkg build from requiring Vite-only plugins

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -52,7 +52,10 @@ function registerErrorHandler() {
 (async () => {
   const server = createServer(app);
 
-  if (app.get("env") === "development") {
+  const runningInPkg = typeof process.pkg !== "undefined";
+  const isDevelopment = app.get("env") === "development" && !runningInPkg;
+
+  if (isDevelopment) {
     await setupVite(app, server);
   } else {
     serveStatic(app);

--- a/server/src/vite.ts
+++ b/server/src/vite.ts
@@ -5,7 +5,6 @@ import { fileURLToPath } from "url";
 import { createServer as createViteServer, createLogger, type ServerOptions } from "vite";
 import { type Server } from "http";
 import { nanoid } from "nanoid";
-import viteConfig from "../../vite.config";
 
 const moduleFilename =
   typeof __filename === "string"
@@ -32,6 +31,8 @@ export async function setupVite(app: Express, server: Server) {
     hmr: { server },
     allowedHosts: true,
   };
+
+  const { default: viteConfig } = await import("../../vite.config.ts");
 
   const vite = await createViteServer({
     ...viteConfig,


### PR DESCRIPTION
## Summary
- skip Vite dev server boot when running from a pkg-built executable
- lazy-load the Vite configuration only when the dev server is actually needed

## Testing
- npm run build
- node scripts/build-standalone.mjs

------
https://chatgpt.com/codex/tasks/task_e_68decc6771b08329a3299613be12f138