### PR TITLE
Fix standalone build packaging for Drizzle ORM

### DIFF
--- a/pkg.standalone.json
+++ b/pkg.standalone.json
@@ -1,0 +1,12 @@
+{
+  "scripts": [
+    "node_modules/drizzle-orm/*.cjs",
+    "node_modules/drizzle-orm/sql/**/*.cjs",
+    "node_modules/drizzle-orm/query-builders/**/*.cjs",
+    "node_modules/drizzle-orm/better-sqlite3/**/*.cjs",
+    "node_modules/drizzle-orm/sqlite-core/**/*.cjs"
+  ],
+  "assets": [
+    "node_modules/drizzle-orm/package.json"
+  ]
+}

--- a/scripts/build-standalone.mjs
+++ b/scripts/build-standalone.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { execSync } from "node:child_process";
+import { execSync, execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -15,10 +15,17 @@ const outputRoot = path.join(rootDir, "standalone", "win-x64");
 const outputExe = path.join(outputRoot, "DreamShards.exe");
 const pkgTarget = "node18-win-x64";
 const sqliteBinary = path.join(rootDir, "node_modules", "better-sqlite3", "build", "Release", "better_sqlite3.node");
+const pkgNodeVersion = "18.5.0";
+let windowsSqliteBinaryBuffer = null;
+const pkgConfigFile = path.join(rootDir, "pkg.standalone.json");
 const databaseFile = path.join(rootDir, "server", "dreamshards.db");
 
 function run(command) {
   execSync(command, { stdio: "inherit", cwd: rootDir });
+}
+
+function runBin(binary, args, options = {}) {
+  execFileSync(binary, args, { stdio: "inherit", cwd: options.cwd ?? rootDir });
 }
 
 function ensureBuildArtifacts() {
@@ -40,8 +47,7 @@ function ensureBuildArtifacts() {
 function buildCommonJsServerBundle() {
   console.log("⚙️  Creating CommonJS server bundle for pkg...");
   const relativeOutput = path.relative(rootDir, serverStandaloneBundle);
-  const esbuildCommand = [
-    "npx",
+  const esbuildArgs = [
     "esbuild",
     path.join("server", "src", "index.ts"),
     "--platform=node",
@@ -49,8 +55,8 @@ function buildCommonJsServerBundle() {
     "--bundle",
     "--format=cjs",
     `--outfile=${relativeOutput}`,
-  ].join(" ");
-  run(esbuildCommand);
+  ];
+  runBin("npx", esbuildArgs);
 
   if (!fs.existsSync(serverStandaloneBundle)) {
     throw new Error("Failed to create CommonJS server bundle for pkg.");
@@ -74,30 +80,86 @@ function copyStaticAssets() {
     fs.copyFileSync(databaseFile, path.join(targetDbDir, path.basename(databaseFile)));
   }
 
+  if (!windowsSqliteBinaryBuffer) {
+    throw new Error("better-sqlite3 Windows binary was not prepared.");
+  }
+
+  fs.writeFileSync(
+    path.join(outputRoot, path.basename(sqliteBinary)),
+    windowsSqliteBinaryBuffer,
+  );
+}
+
+function ensureBetterSqliteBinary() {
+  console.log(`⚙️  Ensuring better-sqlite3 native addon for Node ${pkgNodeVersion} (win32-x64)...`);
+  const moduleDir = path.join(rootDir, "node_modules", "better-sqlite3");
+
+  if (!fs.existsSync(moduleDir)) {
+    throw new Error("better-sqlite3 is not installed. Did you run npm install?");
+  }
+
   if (!fs.existsSync(sqliteBinary)) {
     throw new Error("Could not locate better-sqlite3 native binary. Did you run npm install?");
   }
-  fs.copyFileSync(sqliteBinary, path.join(outputRoot, path.basename(sqliteBinary)));
+
+  const originalBinary = fs.readFileSync(sqliteBinary);
+
+  try {
+    runBin(
+      "npx",
+      [
+        "prebuild-install",
+        "--target",
+        pkgNodeVersion,
+        "--runtime",
+        "node",
+        "--platform",
+        "win32",
+        "--arch",
+        "x64",
+      ],
+      { cwd: moduleDir },
+    );
+
+    if (!fs.existsSync(sqliteBinary)) {
+      throw new Error("Failed to download better-sqlite3 Windows binary.");
+    }
+
+    windowsSqliteBinaryBuffer = fs.readFileSync(sqliteBinary);
+  } finally {
+    fs.writeFileSync(sqliteBinary, originalBinary);
+  }
+
+  if (!windowsSqliteBinaryBuffer || windowsSqliteBinaryBuffer.length === 0) {
+    throw new Error("Downloaded better-sqlite3 Windows binary was empty.");
+  }
 }
 
 function createExecutable() {
   console.log("⚙️  Bundling Windows executable with pkg...");
-  const pkgCommand = [
-    "npx",
+  if (!fs.existsSync(pkgConfigFile)) {
+    throw new Error(`Missing pkg configuration at ${pkgConfigFile}`);
+  }
+
+  const pkgArgs = [
     "pkg",
     path.relative(rootDir, serverStandaloneBundle),
     "--target",
     pkgTarget,
     "--output",
-    outputExe,
-  ].join(" ");
-  run(pkgCommand);
+    path.relative(rootDir, outputExe),
+    "--config",
+    path.relative(rootDir, pkgConfigFile),
+  ];
+
+  runBin("npx", pkgArgs);
 }
 
 function main() {
   ensureBuildArtifacts();
   buildCommonJsServerBundle();
   prepareOutputDirectory();
+  ensureBetterSqliteBinary();
   copyStaticAssets();
   createExecutable();
   console.log(`✅ Standalone build created at ${outputRoot} (target ${pkgTarget})`);

--- a/server/src/vite.ts
+++ b/server/src/vite.ts
@@ -4,7 +4,6 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { createServer as createViteServer, createLogger, type ServerOptions } from "vite";
 import { type Server } from "http";
-import { nanoid } from "nanoid";
 
 const moduleFilename =
   typeof __filename === "string"
@@ -33,6 +32,7 @@ export async function setupVite(app: Express, server: Server) {
   };
 
   const { default: viteConfig } = await import("../../vite.config.ts");
+  const { nanoid } = await import("nanoid");
 
   const vite = await createViteServer({
     ...viteConfig,


### PR DESCRIPTION
## Summary
- add a pkg configuration so pkg keeps the CommonJS Drizzle ORM runtime files
- update the standalone build script to download the Windows better-sqlite3 binary, write it into the bundle, and call pkg with the shared config
- defer loading nanoid to a dynamic import so the CommonJS bundle no longer tries to require its ESM entry point

## Testing
- node scripts/build-standalone.mjs

------
https://chatgpt.com/codex/tasks/task_e_68dece4bd9e4832989921fbe8569d4d2