### PR TITLE
Ensure desktop build bootstraps tooling and clean without rimraf

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Key gameplay content lives under `shared/content/`:
 npm install
 ```
 
-This installs both runtime and development dependencies (including `@types/better-sqlite3` for the server).
+This installs both runtime and development dependencies (including `@types/better-sqlite3` for the server) and automatically bootstraps the Electron workspace under `desktop/`—even when installing with production flags—so commands such as `npm run desktop:dev` and `npm run desktop:build` have access to the required Electron tooling without any extra manual steps.
 
 ## Available Scripts
 

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -11,7 +11,6 @@
         "concurrently": "^8.2.2",
         "electron": "^33.2.1",
         "electron-builder": "^24.13.3",
-        "rimraf": "^6.0.1",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
         "typescript": "^5.6.3",
@@ -347,29 +346,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -3735,119 +3711,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
-      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^11.0.0",
-        "package-json-from-dist": "^1.0.0"
-      },
-      "bin": {
-        "rimraf": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/glob": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
-      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.0.3",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/jackspeak": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
-      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/lru-cache": {
-      "version": "11.2.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
-      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/rimraf/node_modules/minimatch": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
-      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/rimraf/node_modules/path-scurry": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
-      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/roarr": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -5,7 +5,7 @@
   "type": "commonjs",
   "main": "dist/main/index.js",
   "scripts": {
-    "clean": "rimraf ../dist/desktop",
+    "clean": "node ./scripts/clean.cjs",
     "typecheck": "tsc --build tsconfig.json",
     "dev": "concurrently -k \"npm:dev:renderer\" \"npm:dev:main\"",
     "dev:renderer": "vite dev --config ../vite.config.ts",
@@ -20,7 +20,6 @@
     "concurrently": "^8.2.2",
     "electron": "^33.2.1",
     "electron-builder": "^24.13.3",
-    "rimraf": "^6.0.1",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.6.3",

--- a/desktop/scripts/clean.cjs
+++ b/desktop/scripts/clean.cjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+
+const target = path.resolve(__dirname, '..', '..', 'dist', 'desktop');
+
+try {
+  fs.rmSync(target, { recursive: true, force: true });
+  process.exit(0);
+} catch (error) {
+  console.error(`Failed to remove ${target}:`, error);
+  process.exitCode = 1;
+}

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
     "start": "NODE_ENV=production node dist/server/index.js",
     "build:standalone:win": "node scripts/build-standalone.mjs",
     "check": "tsc",
+    "postinstall": "npm run bootstrap:desktop",
+    "bootstrap:desktop": "npm install --prefix desktop --production=false",
     "db:push": "drizzle-kit push --config server/drizzle.config.ts",
     "desktop:dev": "npm run dev --prefix desktop",
-    "desktop:build": "npm run package --prefix desktop"
+    "desktop:build": "npm run bootstrap:desktop && npm run package --prefix desktop"
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.5",


### PR DESCRIPTION
## Summary
- add a reusable bootstrap script that installs the desktop workspace with development dependencies and invoke it from postinstall and desktop:build
- replace the desktop clean step with a Node-based script so the build no longer depends on rimraf being present on PATH
- clarify the README to explain that desktop tooling is automatically prepared without extra steps

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dee88daa6c832988fd1abca0583b33