### PR TITLE
Fix Electron desktop build configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ standalone
 server/public
 vite.config.ts.*
 *.tar.gz
+*.tsbuildinfo

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -10,8 +10,9 @@
     "dev": "concurrently -k \"npm:dev:renderer\" \"npm:dev:main\"",
     "dev:renderer": "vite dev --config ../vite.config.ts",
     "dev:main": "wait-on tcp:5173 && electron -r ts-node/register/transpile-only -r tsconfig-paths/register ./src/main/index.ts",
-    "build": "npm run clean && npm run build:renderer && npm run build:main && npm run build:preload",
+    "build": "npm run clean && npm run build:renderer && npm run copy:public && npm run build:main && npm run build:preload",
     "build:renderer": "vite build --config ../vite.config.ts",
+    "copy:public": "node ./scripts/copy-public.cjs",
     "build:main": "tsc --project tsconfig.main.json",
     "build:preload": "tsc --project tsconfig.preload.json",
     "package": "npm run build && electron-builder"
@@ -24,5 +25,12 @@
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.6.3",
     "wait-on": "^7.2.0"
+  },
+  "build": {
+    "files": [
+      "dist/main/**/*",
+      "dist/preload/**/*",
+      "dist/public/**/*"
+    ]
   }
 }

--- a/desktop/scripts/clean.cjs
+++ b/desktop/scripts/clean.cjs
@@ -2,12 +2,16 @@
 const fs = require('node:fs');
 const path = require('node:path');
 
-const target = path.resolve(__dirname, '..', '..', 'dist', 'desktop');
+const targets = [
+  path.resolve(__dirname, '..', '..', 'dist', 'desktop'),
+  path.resolve(__dirname, '..', 'dist')
+];
 
-try {
-  fs.rmSync(target, { recursive: true, force: true });
-  process.exit(0);
-} catch (error) {
-  console.error(`Failed to remove ${target}:`, error);
-  process.exitCode = 1;
+for (const target of targets) {
+  try {
+    fs.rmSync(target, { recursive: true, force: true });
+  } catch (error) {
+    console.error(`Failed to remove ${target}:`, error);
+    process.exitCode = 1;
+  }
 }

--- a/desktop/scripts/copy-public.cjs
+++ b/desktop/scripts/copy-public.cjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+
+const source = path.resolve(__dirname, '..', '..', 'dist', 'public');
+const destination = path.resolve(__dirname, '..', 'dist', 'public');
+
+if (!fs.existsSync(source)) {
+  console.error(`Source assets not found at ${source}. Have you run the renderer build?`);
+  process.exit(1);
+}
+
+fs.rmSync(destination, { recursive: true, force: true });
+fs.mkdirSync(destination, { recursive: true });
+
+fs.cpSync(source, destination, { recursive: true });

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -1,0 +1,54 @@
+import { app, BrowserWindow, shell } from 'electron';
+import path from 'node:path';
+import url from 'node:url';
+
+const isDev = !app.isPackaged;
+
+const createWindow = () => {
+  const win = new BrowserWindow({
+    width: 1280,
+    height: 720,
+    show: false,
+    autoHideMenuBar: true,
+    webPreferences: {
+      preload: path.join(__dirname, '..', 'preload', 'index.js'),
+      nodeIntegration: false,
+      contextIsolation: true,
+    },
+  });
+
+  if (isDev) {
+    win.loadURL('http://localhost:5173');
+    win.webContents.openDevTools({ mode: 'detach' });
+  } else {
+    win.loadURL(
+      url.format({
+        pathname: path.join(__dirname, '..', 'public', 'index.html'),
+        protocol: 'file:',
+        slashes: true,
+      }),
+    );
+  }
+
+  win.once('ready-to-show', () => win.show());
+  win.webContents.setWindowOpenHandler(({ url: externalUrl }) => {
+    shell.openExternal(externalUrl);
+    return { action: 'deny' };
+  });
+};
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow();
+    }
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -1,0 +1,9 @@
+import { contextBridge } from 'electron';
+
+declare global {
+  interface Window {
+    desktop: Record<string, never>;
+  }
+}
+
+contextBridge.exposeInMainWorld('desktop', {});

--- a/desktop/tsconfig.main.json
+++ b/desktop/tsconfig.main.json
@@ -2,14 +2,16 @@
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
-    "module": "CommonJS",
+    "module": "Node16",
     "moduleResolution": "node16",
     "target": "ES2022",
     "lib": ["es2022"],
     "rootDir": "./src/main",
-    "outDir": "../dist/desktop/main",
+    "outDir": "./dist/main",
     "noEmit": false,
+    "allowImportingTsExtensions": false,
     "types": ["node", "electron"]
   },
-  "include": ["src/main/**/*.ts"]
+  "include": ["src/main/**/*.ts"],
+  "exclude": ["./dist/main"]
 }

--- a/desktop/tsconfig.preload.json
+++ b/desktop/tsconfig.preload.json
@@ -2,14 +2,16 @@
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
-    "module": "CommonJS",
+    "module": "Node16",
     "moduleResolution": "node16",
     "target": "ES2022",
     "lib": ["es2022", "dom"],
     "rootDir": "./src/preload",
-    "outDir": "../dist/desktop/preload",
+    "outDir": "./dist/preload",
     "noEmit": false,
+    "allowImportingTsExtensions": false,
     "types": ["node", "electron"]
   },
-  "include": ["src/preload/**/*.ts"]
+  "include": ["src/preload/**/*.ts"],
+  "exclude": ["./dist/preload"]
 }


### PR DESCRIPTION
## Summary
- add Electron main and preload entrypoints with production asset loading
- update desktop TypeScript configuration and build scripts to emit to desktop/dist and copy renderer assets for packaging
- ensure generated build artifacts are ignored and cleaned during builds

## Testing
- npm run desktop:build

------
https://chatgpt.com/codex/tasks/task_e_68deecc84dd8832982b3894b628c862c