### PR TITLE
Ensure desktop dev installs dependencies automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "postinstall": "npm run bootstrap:desktop",
     "bootstrap:desktop": "npm install --prefix desktop --production=false",
     "db:push": "drizzle-kit push --config server/drizzle.config.ts",
-    "desktop:dev": "npm run dev --prefix desktop",
-    "desktop:build": "npm run bootstrap:desktop && npm run package --prefix desktop"
+    "desktop:dev": "node scripts/ensure-desktop-deps.mjs && npm run dev --prefix desktop",
+    "desktop:build": "node scripts/ensure-desktop-deps.mjs && npm run package --prefix desktop"
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.5",

--- a/scripts/ensure-desktop-deps.mjs
+++ b/scripts/ensure-desktop-deps.mjs
@@ -1,0 +1,37 @@
+import { existsSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { spawn } from 'child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__dirname, '..');
+const desktopDir = resolve(projectRoot, 'desktop');
+const binName = process.platform === 'win32' ? 'concurrently.cmd' : 'concurrently';
+const concurrentlyBin = resolve(desktopDir, 'node_modules', '.bin', binName);
+
+if (existsSync(concurrentlyBin)) {
+  process.exit(0);
+}
+
+console.log('Desktop dependencies not found. Installing desktop workspace...');
+
+const install = spawn('npm', ['install', '--prefix', 'desktop', '--production=false'], {
+  cwd: projectRoot,
+  stdio: 'inherit',
+  shell: process.platform === 'win32',
+});
+
+install.on('error', (error) => {
+  console.error('Failed to install desktop dependencies:', error);
+  process.exit(1);
+});
+
+install.on('exit', (code) => {
+  if (code === 0) {
+    console.log('Desktop dependencies installed successfully.');
+    process.exit(0);
+  }
+
+  console.error(`Desktop dependency installation exited with code ${code}.`);
+  process.exit(code ?? 1);
+});


### PR DESCRIPTION
## Summary
- add a helper script that installs the desktop workspace when its toolchain is missing
- ensure the desktop development and build scripts invoke the helper before running

## Testing
- node scripts/ensure-desktop-deps.mjs
- npm run desktop:dev *(fails in CI containers because Electron requires system libraries)*

------
https://chatgpt.com/codex/tasks/task_e_68deef77800c8329a3db68c6b4549795