### PR TITLE
Handle stale desktop node_modules before reinstall

### DIFF
--- a/scripts/ensure-desktop-deps.mjs
+++ b/scripts/ensure-desktop-deps.mjs
@@ -1,4 +1,4 @@
-import { existsSync } from 'fs';
+import { existsSync, rmSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { spawn } from 'child_process';
@@ -7,7 +7,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = resolve(__dirname, '..');
 const desktopDir = resolve(projectRoot, 'desktop');
 const binName = process.platform === 'win32' ? 'concurrently.cmd' : 'concurrently';
-const concurrentlyBin = resolve(desktopDir, 'node_modules', '.bin', binName);
+const desktopNodeModules = resolve(desktopDir, 'node_modules');
+const concurrentlyBin = resolve(desktopNodeModules, '.bin', binName);
 
 if (existsSync(concurrentlyBin)) {
   process.exit(0);
@@ -15,10 +16,27 @@ if (existsSync(concurrentlyBin)) {
 
 console.log('Desktop dependencies not found. Installing desktop workspace...');
 
-const install = spawn('npm', ['install', '--prefix', 'desktop', '--production=false'], {
+if (existsSync(desktopNodeModules)) {
+  try {
+    console.log('Removing stale desktop node_modules directory...');
+    rmSync(desktopNodeModules, { recursive: true, force: true, maxRetries: 3 });
+  } catch (error) {
+    console.warn('Failed to remove desktop node_modules before reinstalling:', error);
+  }
+}
+
+const npmExecPath = process.env.npm_execpath;
+let command = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+let args = ['install', '--prefix', 'desktop', '--production=false'];
+
+if (npmExecPath?.endsWith('.js')) {
+  command = process.execPath;
+  args = [npmExecPath, ...args];
+}
+
+const install = spawn(command, args, {
   cwd: projectRoot,
   stdio: 'inherit',
-  shell: process.platform === 'win32',
 });
 
 install.on('error', (error) => {


### PR DESCRIPTION
## Summary
- remove stale desktop node_modules before reinstalling dependencies to avoid Windows permission errors
- reuse the computed node_modules path for checking concurrently binary presence

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68def0cb1204832989544e6e5d584677