### PR TITLE
Fix Electron dev script to use ts-node ESM loader

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "devDependencies": {
         "concurrently": "^8.2.2",
+        "cross-env": "^7.0.3",
         "electron": "^33.2.1",
         "electron-builder": "^24.13.3",
         "ts-node": "^10.9.2",
@@ -1712,6 +1713,25 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc --build tsconfig.json",
     "dev": "concurrently -k \"npm:dev:renderer\" \"npm:dev:main\"",
     "dev:renderer": "vite dev --config ../vite.config.ts",
-    "dev:main": "wait-on tcp:5173 && electron -r ts-node/register/transpile-only -r tsconfig-paths/register ./src/main/index.ts",
+    "dev:main": "wait-on tcp:5173 && cross-env NODE_OPTIONS=\"--loader ts-node/esm --loader tsconfig-paths/register --no-warnings\" electron ./src/main/index.ts",
     "build": "npm run clean && npm run build:renderer && npm run copy:public && npm run build:main && npm run build:preload",
     "build:renderer": "vite build --config ../vite.config.ts",
     "copy:public": "node ./scripts/copy-public.cjs",
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "concurrently": "^8.2.2",
+    "cross-env": "^7.0.3",
     "electron": "^33.2.1",
     "electron-builder": "^24.13.3",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
## Summary
- update the Electron dev:main script to opt into the ts-node ESM and tsconfig-paths loaders via NODE_OPTIONS
- add cross-env so NODE_OPTIONS is set consistently on all platforms

## Testing
- npm run desktop:dev *(fails: vite binary not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68defea1eab483298f6155357dcdf596