### PR TITLE
Fix Electron dev startup with ts-node bootstrap

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc --build tsconfig.json",
     "dev": "concurrently -k \"npm:dev:renderer\" \"npm:dev:main\"",
     "dev:renderer": "vite dev --config ../vite.config.ts",
-    "dev:main": "wait-on tcp:5173 && cross-env TS_NODE_PROJECT=tsconfig.main.json NODE_OPTIONS=\"--no-warnings\" electron -r ts-node/register/transpile-only -r tsconfig-paths/register ./src/main/index.ts",
+    "dev:main": "wait-on tcp:5173 && cross-env TS_NODE_PROJECT=tsconfig.main.json NODE_OPTIONS=\"--no-warnings\" electron ./scripts/start-main.cjs",
     "build": "npm run clean && npm run build:renderer && npm run copy:public && npm run build:main && npm run build:preload",
     "build:renderer": "vite build --config ../vite.config.ts",
     "copy:public": "node ./scripts/copy-public.cjs",

--- a/desktop/scripts/start-main.cjs
+++ b/desktop/scripts/start-main.cjs
@@ -1,0 +1,8 @@
+require('ts-node/register/transpile-only');
+require('tsconfig-paths/register');
+
+const path = require('node:path');
+
+const mainEntry = path.join(__dirname, '..', 'src', 'main', 'index.ts');
+
+require(mainEntry);


### PR DESCRIPTION
## Summary
- add a bootstrap script that registers ts-node and tsconfig-paths before loading the Electron main process entry
- update the dev:main script to launch Electron through the bootstrap to avoid the unknown .ts extension error during development

## Testing
- not run (dev command starts long-running Electron/Vite processes)


------
https://chatgpt.com/codex/tasks/task_e_68df71e296448329a114184e09eb08e9