### PR TITLE
Ensure Tailwind config loads during desktop builds

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,16 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const moduleFilename =
+  typeof __filename === "string" ? __filename : fileURLToPath(import.meta.url);
+const moduleDirname =
+  typeof __dirname === "string" ? __dirname : dirname(moduleFilename);
+
 export default {
   plugins: {
-    tailwindcss: {},
+    tailwindcss: {
+      config: resolve(moduleDirname, "tailwind.config.ts"),
+    },
     autoprefixer: {},
   },
-}
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,1 +1,29 @@
-export { default } from "./client/tailwind.config";
+import baseConfig from "./client/tailwind.config";
+import type { Config } from "tailwindcss";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const moduleFilename =
+  typeof __filename === "string" ? __filename : fileURLToPath(import.meta.url);
+const moduleDirname =
+  typeof __dirname === "string" ? __dirname : dirname(moduleFilename);
+
+const contentGlobs = (baseConfig.content ?? [])
+  .map((glob) => {
+    if (typeof glob !== "string") {
+      return glob;
+    }
+
+    if (glob.startsWith("./")) {
+      return resolve(moduleDirname, "client", glob.slice(2));
+    }
+
+    return resolve(moduleDirname, "client", glob);
+  });
+
+const config: Config = {
+  ...baseConfig,
+  content: contentGlobs,
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- convert the shared Tailwind config to emit absolute content globs so it works outside the client workspace
- point PostCSS at the repo Tailwind config to avoid missing content when building from the desktop package

## Testing
- npm run build --prefix desktop
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68df793e5a84832988159ef8df2063db