### PR TITLE
Silence Autofill devtools errors in Electron dev mode

### DIFF
--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -38,6 +38,24 @@ const createWindow = () => {
 };
 
 app.whenReady().then(() => {
+  app.on('web-contents-created', (_event, contents) => {
+    contents.once('dom-ready', () => {
+      if (!contents.getURL().startsWith('devtools://')) {
+        return;
+      }
+
+      contents.on('console-message', (event, level, message) => {
+        if (
+          level >= 2 &&
+          (message.includes("'Autofill.enable' wasn't found") ||
+            message.includes("'Autofill.setAddresses' wasn't found"))
+        ) {
+          event.preventDefault?.();
+        }
+      });
+    });
+  });
+
   createWindow();
 
   app.on('activate', () => {


### PR DESCRIPTION
## Summary
- hook into Electron's devtools WebContents during app startup
- suppress repeated Autofill protocol console errors emitted by Chromium devtools

## Testing
- npm run typecheck --prefix desktop

------
https://chatgpt.com/codex/tasks/task_e_68df7cc7ea0c8329af094b8d427068e9