### PR TITLE
Disable Windows executable signing during packaging

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -32,6 +32,9 @@
       "dist/main/**/*",
       "dist/preload/**/*",
       "dist/public/**/*"
-    ]
+    ],
+    "win": {
+      "signAndEditExecutable": false
+    }
   }
 }


### PR DESCRIPTION
## Summary
- disable executable signing and resource editing in the desktop build so Electron Builder no longer downloads the winCodeSign bundle that fails to unpack on Windows without symlink permissions

## Testing
- npm run desktop:build

------
https://chatgpt.com/codex/tasks/task_e_68df7f19ea0c8329949d826fe2b475df