### PR TITLE
Fix desktop clean script to remove stale TypeScript outputs

### DIFF
--- a/desktop/scripts/clean.cjs
+++ b/desktop/scripts/clean.cjs
@@ -4,7 +4,9 @@ const path = require('node:path');
 
 const targets = [
   path.resolve(__dirname, '..', '..', 'dist', 'desktop'),
-  path.resolve(__dirname, '..', 'dist')
+  path.resolve(__dirname, '..', 'dist'),
+  path.resolve(__dirname, '..', 'tsconfig.main.tsbuildinfo'),
+  path.resolve(__dirname, '..', 'tsconfig.preload.tsbuildinfo')
 ];
 
 for (const target of targets) {


### PR DESCRIPTION
## Summary
- remove cached TypeScript build info files in the desktop clean script so fresh builds recreate main/preload bundles

## Testing
- npm run package

------
https://chatgpt.com/codex/tasks/task_e_68df812ed94083299025848cb12150a9