### PR TITLE
Fix Electron desktop asset loading in production

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -11,7 +11,7 @@
     "dev:renderer": "vite dev --config ../vite.config.ts",
     "dev:main": "wait-on tcp:5173 && cross-env TS_NODE_PROJECT=tsconfig.main.json NODE_OPTIONS=\"--no-warnings\" electron ./scripts/start-main.cjs",
     "build": "npm run clean && npm run build:renderer && npm run copy:public && npm run build:main && npm run build:preload",
-    "build:renderer": "vite build --config ../vite.config.ts",
+    "build:renderer": "cross-env VITE_BUILD_TARGET=desktop vite build --config ../vite.config.ts",
     "copy:public": "node ./scripts/copy-public.cjs",
     "build:main": "tsc --project tsconfig.main.json",
     "build:preload": "tsc --project tsconfig.preload.json",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,12 +12,15 @@ const moduleFilename =
 const moduleDirname =
   typeof __dirname === "string" ? __dirname : dirname(moduleFilename);
 
+const isDesktopBuild = process.env.VITE_BUILD_TARGET === "desktop";
+
 export default defineConfig({
   plugins: [
     react(),
     runtimeErrorOverlay(),
     glsl(), // Add GLSL shader support
   ],
+  base: isDesktopBuild ? "./" : "/",
   resolve: {
     alias: {
       "@": path.resolve(moduleDirname, "client", "src"),


### PR DESCRIPTION
## Summary
- set the Vite build base to a relative path when targeting the desktop app
- propagate a VITE_BUILD_TARGET flag from the desktop renderer build script

## Testing
- npm run desktop:build

------
https://chatgpt.com/codex/tasks/task_e_68df84fe3b408329936d79ca25bceb07