### PR TITLE
Ensure desktop scripts run via active npm runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "build:standalone:win": "node scripts/build-standalone.mjs",
     "check": "tsc",
     "postinstall": "npm run bootstrap:desktop",
-    "bootstrap:desktop": "npm install --prefix desktop --production=false",
+    "bootstrap:desktop": "node scripts/install-desktop-deps.mjs",
     "db:push": "drizzle-kit push --config server/drizzle.config.ts",
-    "desktop:dev": "node scripts/ensure-desktop-deps.mjs && npm run dev --prefix desktop",
-    "desktop:build": "node scripts/ensure-desktop-deps.mjs && npm run package --prefix desktop"
+    "desktop:dev": "node scripts/ensure-desktop-deps.mjs && node scripts/run-desktop-script.mjs dev",
+    "desktop:build": "node scripts/ensure-desktop-deps.mjs && node scripts/run-desktop-script.mjs package"
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.5",

--- a/scripts/install-desktop-deps.mjs
+++ b/scripts/install-desktop-deps.mjs
@@ -1,0 +1,28 @@
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { runNpmCommand } from './npm-command.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const defaultProjectRoot = resolve(__dirname, '..');
+
+const INSTALL_ARGS = ['install', '--prefix', 'desktop', '--production=false'];
+
+export function installDesktopDependencies({ projectRoot = defaultProjectRoot } = {}) {
+  return runNpmCommand(INSTALL_ARGS, {
+    cwd: projectRoot,
+    displayName: 'Desktop dependency installation',
+  });
+}
+
+async function runAsScript() {
+  try {
+    await installDesktopDependencies({ projectRoot: defaultProjectRoot });
+  } catch (error) {
+    console.error('Failed to install desktop dependencies:', error);
+    process.exit(typeof error?.code === 'number' ? error.code : 1);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  runAsScript();
+}

--- a/scripts/npm-command.mjs
+++ b/scripts/npm-command.mjs
@@ -1,0 +1,61 @@
+import { spawn } from 'child_process';
+
+function createNpmInvocation(args) {
+  const npmExecPath = process.env.npm_execpath;
+
+  if (npmExecPath?.endsWith('.js')) {
+    return {
+      command: process.execPath,
+      args: [npmExecPath, ...args],
+    };
+  }
+
+  if (process.platform === 'win32') {
+    return {
+      command: 'npm.cmd',
+      args,
+    };
+  }
+
+  return {
+    command: 'npm',
+    args,
+  };
+}
+
+export function runNpmCommand(args, { cwd = process.cwd(), stdio = 'inherit', displayName } = {}) {
+  const label = displayName ?? `npm ${args.join(' ')}`;
+
+  return new Promise((resolve, reject) => {
+    const { command, args: commandArgs } = createNpmInvocation(args);
+
+    const child = spawn(command, commandArgs, {
+      cwd,
+      stdio,
+    });
+
+    child.on('error', (error) => {
+      reject(error);
+    });
+
+    child.on('exit', (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      const reason = signal ? `terminated with signal ${signal}` : `exited with code ${code}`;
+      const error = new Error(`${label} ${reason}.`);
+
+      if (typeof code === 'number') {
+        error.code = code;
+      }
+
+      if (signal) {
+        error.signal = signal;
+      }
+
+      reject(error);
+    });
+  });
+}

--- a/scripts/run-desktop-script.mjs
+++ b/scripts/run-desktop-script.mjs
@@ -1,0 +1,51 @@
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { runNpmCommand } from './npm-command.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const defaultProjectRoot = resolve(__dirname, '..');
+
+export function runDesktopScript(scriptName, { projectRoot = defaultProjectRoot, npmOptions = [], scriptArgs = [] } = {}) {
+  if (!scriptName) {
+    return Promise.reject(new Error('A desktop npm script name must be provided.'));
+  }
+
+  const commandArgs = ['run', scriptName, '--prefix', 'desktop', ...npmOptions];
+
+  if (scriptArgs.length > 0) {
+    commandArgs.push('--', ...scriptArgs);
+  }
+
+  return runNpmCommand(commandArgs, {
+    cwd: projectRoot,
+    displayName: `Desktop script "${scriptName}"`,
+  });
+}
+
+async function runAsScript() {
+  const [, , scriptName, ...rest] = process.argv;
+
+  if (!scriptName) {
+    console.error('Usage: node scripts/run-desktop-script.mjs <script> [npm options...] [-- <script args...>]');
+    process.exit(1);
+  }
+
+  const separatorIndex = rest.indexOf('--');
+  const npmOptions = separatorIndex === -1 ? rest : rest.slice(0, separatorIndex);
+  const scriptArgs = separatorIndex === -1 ? [] : rest.slice(separatorIndex + 1);
+
+  try {
+    await runDesktopScript(scriptName, {
+      projectRoot: defaultProjectRoot,
+      npmOptions,
+      scriptArgs,
+    });
+  } catch (error) {
+    console.error(`Failed to run desktop script "${scriptName}":`, error);
+    process.exit(typeof error?.code === 'number' ? error.code : 1);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  runAsScript();
+}


### PR DESCRIPTION
## Summary
- add a reusable npm command helper that runs through the active runtime on all platforms
- refactor the desktop dependency installer to use the shared helper
- route desktop dev/build scripts through the helper to avoid missing npm binaries on Windows

## Testing
- npm run desktop:build

------
https://chatgpt.com/codex/tasks/task_e_68e017f84880832999d4bd4329d4bb58