### PR TITLE
Fix Electron type usage in main process

### DIFF
--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -31,20 +31,20 @@ const createWindow = () => {
   }
 
   win.once('ready-to-show', () => win.show());
-  win.webContents.setWindowOpenHandler(({ url: externalUrl }) => {
+  win.webContents.setWindowOpenHandler(({ url: externalUrl }: Electron.HandlerDetails) => {
     shell.openExternal(externalUrl);
     return { action: 'deny' };
   });
 };
 
 app.whenReady().then(() => {
-  app.on('web-contents-created', (_event, contents) => {
+  app.on('web-contents-created', (_event: Electron.Event, contents: Electron.WebContents) => {
     contents.once('dom-ready', () => {
       if (!contents.getURL().startsWith('devtools://')) {
         return;
       }
 
-      contents.on('console-message', (event, level, message) => {
+      contents.on('console-message', (event: Electron.Event, level: number, message: string) => {
         if (
           level >= 2 &&
           (message.includes("'Autofill.enable' wasn't found") ||

--- a/desktop/tsconfig.main.json
+++ b/desktop/tsconfig.main.json
@@ -11,7 +11,7 @@
     "noEmit": false,
     "allowImportingTsExtensions": false,
     "types": ["node", "electron"],
-    "typeRoots": ["./types", "./node_modules/@types"]
+    "typeRoots": ["./types", "./node_modules/@types", "../node_modules/@types"]
   },
   "include": ["src/main/**/*.ts"],
   "exclude": ["./dist/main"]

--- a/desktop/tsconfig.preload.json
+++ b/desktop/tsconfig.preload.json
@@ -11,7 +11,7 @@
     "noEmit": false,
     "allowImportingTsExtensions": false,
     "types": ["node", "electron"],
-    "typeRoots": ["./types", "./node_modules/@types"]
+    "typeRoots": ["./types", "./node_modules/@types", "../node_modules/@types"]
   },
   "include": ["src/preload/**/*.ts"],
   "exclude": ["./dist/preload"]

--- a/desktop/types/electron/index.d.ts
+++ b/desktop/types/electron/index.d.ts
@@ -1,1 +1,21 @@
 /// <reference path="../../node_modules/electron/electron.d.ts" />
+
+declare module 'electron' {
+  export = Electron.CrossProcessExports;
+}
+
+declare module 'electron/main' {
+  export = Electron.Main;
+}
+
+declare module 'electron/common' {
+  export = Electron.Common;
+}
+
+declare module 'electron/renderer' {
+  export = Electron.Renderer;
+}
+
+declare module 'electron/utility' {
+  export = Electron.Utility;
+}


### PR DESCRIPTION
## Summary
- replace explicit type imports from `electron/main` with references to the global `Electron` namespace
- keep the main-process handlers typed without triggering module export errors

## Testing
- npm run desktop:build

------
https://chatgpt.com/codex/tasks/task_e_68e03ae12fe88329a7301f64cb56cdf3