### PR TITLE
Fix desktop tsconfig and typings

### DIFF
--- a/desktop/desktop/package-lock.json
+++ b/desktop/desktop/package-lock.json
@@ -15,6 +15,7 @@
         "dream-shards": "file:.."
       },
       "devDependencies": {
+        "@types/node": "20.16.11",
         "concurrently": "^8.2.2",
         "cross-env": "^7.0.3",
         "electron": "28.3.3",

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -11,14 +11,14 @@
         "dream-shards": "file:.."
       },
       "devDependencies": {
-        "@types/node": "20.16.11",
+        "@types/node": "^20.16.11",
         "concurrently": "^8.2.2",
         "cross-env": "^7.0.3",
-        "electron": "28.3.3",
+        "electron": "^28.3.3",
         "electron-builder": "^24.13.3",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
-        "typescript": "^5.6.3",
+        "typescript": "^5.9.3",
         "wait-on": "^7.2.0"
       }
     },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -18,14 +18,14 @@
     "package": "npm run build && electron-builder"
   },
   "devDependencies": {
+    "@types/node": "^20.16.11",
     "concurrently": "^8.2.2",
     "cross-env": "^7.0.3",
-    "electron": "28.3.3",
+    "electron": "^28.3.3",
     "electron-builder": "^24.13.3",
-    "@types/node": "20.16.11",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^5.6.3",
+    "typescript": "^5.9.3",
     "wait-on": "^7.2.0"
   },
   "build": {

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, shell } from 'electron';
+import type { Event as ElectronEvent, HandlerDetails, WebContents } from 'electron';
 import path from 'node:path';
 import url from 'node:url';
 
@@ -31,20 +32,20 @@ const createWindow = () => {
   }
 
   win.once('ready-to-show', () => win.show());
-  win.webContents.setWindowOpenHandler(({ url: externalUrl }: Electron.HandlerDetails) => {
+  win.webContents.setWindowOpenHandler(({ url: externalUrl }: HandlerDetails) => {
     shell.openExternal(externalUrl);
     return { action: 'deny' };
   });
 };
 
 app.whenReady().then(() => {
-  app.on('web-contents-created', (_event: Electron.Event, contents: Electron.WebContents) => {
+  app.on('web-contents-created', (_event: ElectronEvent, contents: WebContents) => {
     contents.once('dom-ready', () => {
       if (!contents.getURL().startsWith('devtools://')) {
         return;
       }
 
-      contents.on('console-message', (event: Electron.Event, level: number, message: string) => {
+      contents.on('console-message', (event: ElectronEvent, level: number, message: string) => {
         if (
           level >= 2 &&
           (message.includes("'Autofill.enable' wasn't found") ||

--- a/desktop/tsconfig.main.json
+++ b/desktop/tsconfig.main.json
@@ -2,17 +2,20 @@
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
-    "module": "Node16",
-    "moduleResolution": "node16",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
     "target": "ES2022",
-    "lib": ["es2022"],
+    "lib": ["ES2022", "DOM"],
     "rootDir": "./src/main",
     "outDir": "./dist/main",
     "noEmit": false,
     "allowImportingTsExtensions": false,
-    "types": ["node", "electron"],
-    "typeRoots": ["./types", "./node_modules/@types", "../node_modules/@types"]
+    "types": ["electron", "node"],
+    "typeRoots": ["./types", "./node_modules/@types", "../node_modules/@types"],
+    "strict": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true
   },
-  "include": ["src/main/**/*.ts"],
+  "include": ["src/main/**/*", "src/preload/**/*"],
   "exclude": ["./dist/main"]
 }


### PR DESCRIPTION
## Summary
- align the desktop tsconfig overrides with the required Electron and Node compiler options
- replace Electron namespace usages with explicit type imports in the main process entry
- refresh desktop devDependencies to include Electron, TypeScript, and @types/node versions expected by the tooling

## Testing
- npm ls electron
- npm i -D electron @types/node typescript

------
https://chatgpt.com/codex/tasks/task_e_68e0425061b48329acc69ae5ed88af0a